### PR TITLE
Job status check endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ This project is a Flask-based web application that automatically generates tags 
 - Adjustable tag score threshold
 - Response in JSON or HTML format
 - REST API for integration with other services
+- Asynchronous job processing with status checking
 
 ## Setup
 
@@ -19,6 +20,7 @@ This project is a Flask-based web application that automatically generates tags 
    MODEL_PATH=models/model.onnx
    PORT=8000
    DEBUG=False
+   MINIMUM_WAIT_TIME_FOR_BATCHING=10
    ```
 
 2. Download the model and tags:
@@ -43,15 +45,32 @@ This project is a Flask-based web application that automatically generates tags 
 4. For API usage, send POST requests to `/evaluate`. Example using curl:
 
    ```
-   curl -X POST -F "file=@/path/to/your/image.jpg" -F "threshold=0.5" -F "format=json" http://localhost:8000/evaluate
+   curl -X POST -F "file=@/path/to/your/image.jpg" -F "threshold=0.5" -F "format=json" -F "get_id=true" http://localhost:8000/evaluate
    ```
 
-   This command uploads an image file, sets the tag threshold to 0.5, and requests JSON output.
+   This command uploads an image file, sets the tag threshold to 0.5, requests JSON output, and asks for a job ID for asynchronous processing.
 
    Parameters:
 
    - `file`: The image file to upload (can be specified multiple times for batch processing)
    - `threshold`: The minimum confidence score for tags (default: 0.1)
+   - `get_id`: Whether to return a job ID for asynchronous processing (default: false)
+
+   The API will return either:
+   If `get_id` is false:
+   - A JSON array of objects, each containing the filename and its associated tags
+   If `get_id` is true:
+   - A JSON object with a `jobId` field (if `get_id` is true)
+
+5. (Optional if done as a job) To check the status of an asynchronous job, use the `/jobstatus` endpoint:
+
+   ```
+   curl "http://localhost:8000/jobstatus?jobId=your-job-id&format=json"
+   ```
+
+   Parameters:
+
+   - `jobId`: The job ID returned from the initial request
    - `format`: Output format, either 'json' or 'html' (default: 'json')
 
-   The API will return a JSON array of objects, each containing the filename and its associated tags.
+   This will return the job status and results if the job is complete.

--- a/app.py
+++ b/app.py
@@ -1,14 +1,19 @@
 #!/usr/bin/env python
-
+import itertools
 import os
+import threading
+import time
+import uuid
+import io
 from base64 import b64encode
+from collections import defaultdict
 
 import PIL.Image
 from dotenv import load_dotenv
 from flask import Flask, request, render_template, jsonify, abort
 from werkzeug.datastructures import FileStorage
 
-from autotagger import Autotagger
+from autotagger import Autotagger, ProcessImageException
 
 load_dotenv()
 model_path = os.getenv("MODEL_PATH", "models/model.onnx")
@@ -17,6 +22,35 @@ autotagger = Autotagger(model_path)
 app = Flask(__name__)
 app.config["JSON_SORT_KEYS"] = False
 app.config["JSON_PRETTYPRINT_REGULAR"] = True
+
+MINIMUM_WAIT_TIME_FOR_BATCHING = int(os.getenv("MINIMUM_WAIT_TIME_FOR_BATCHING", 10))
+
+thread_to_inputs = defaultdict(list)
+thread_to_results = {}
+thread_to_files = defaultdict(list)
+batch_lock = threading.Lock()
+thread_result_ready_lock = defaultdict(lambda: threading.Semaphore())
+job_results = {}
+
+
+def batch_manager():
+    while True:
+        if not thread_to_inputs:
+            time.sleep(0.1)
+            continue
+        time.sleep(MINIMUM_WAIT_TIME_FOR_BATCHING)
+        with batch_lock:
+            if not thread_to_inputs:
+                continue
+
+            inputs_to_process = list(itertools.chain(*thread_to_inputs.values()))
+            predictions = list(autotagger.predict(inputs_to_process))
+            for thread_id, input_files in list(thread_to_inputs.items()):
+                result = [pred for input_file, pred in zip(inputs_to_process, predictions) if input_file in input_files]
+                job_results[thread_id] = {"status": "complete", "results": result}
+                thread_to_results[thread_id] = result
+                thread_to_inputs.pop(thread_id)
+                thread_result_ready_lock[thread_id].release()
 
 
 @app.route("/", methods=["GET"])
@@ -31,20 +65,52 @@ def evaluate():
     general_threshold = float(request.values.get("general_threshold", threshold))
     character_threshold = float(request.values.get("character_threshold", threshold))
     output: str = request.values.get("format", "json")
-    limit = int(request.values.get("limit", 100))
+    limit: int = int(request.values.get("limit", 100))
+    get_id: bool = request.values.get("get_id", "false").lower() == "true"
 
-    predictions = autotagger.predict(
-        [PIL.Image.open(file.stream) for file in files],
-        general_threshold=general_threshold,
-        character_threshold=character_threshold,
-        limit=limit,
-    )
+    opened_files = []
+    file_streams = []
+    file_names = []
+
+    for file in files:
+        try:
+            file_stream = file.stream.read()
+            file_streams.append(file_stream)
+            image = PIL.Image.open(io.BytesIO(file_stream))
+            opened_files.append(image)
+            file_names.append(file.filename)
+        except PIL.UnidentifiedImageError:
+            abort(400, description=f"Cannot identify image file for file {file.filename}.")
+        except Exception as e:
+            abort(400, description=f"Unknown exception handling opening of file image, {file.filename}: {str(e)}")
+
+    if get_id:
+        job_id: str = str(uuid.uuid4())
+        thread_id: str = job_id
+        thread_result_ready_lock[thread_id].acquire()
+        with batch_lock:
+            thread_to_inputs[thread_id].extend(opened_files)
+            thread_to_files[thread_id] = list(zip(file_names, file_streams))
+        job_results[job_id] = {"status": "processing"}
+        if output == "html":
+            return render_template("job_id_response.html", job_id=job_id)
+        elif output == "json":
+            return jsonify({"jobId": job_id})
+        else:
+            abort(400, description="Invalid output type")
+
+    try:
+        predictions = list(autotagger.predict(
+            opened_files,
+            general_threshold=general_threshold,
+            character_threshold=character_threshold,
+            limit=limit,
+        ))
+    except ProcessImageException as process_image_exception:
+        abort(400, description=f"Error processing image file, {process_image_exception.message}.")
 
     if output == "html":
-        for file in files:
-            file.seek(0)
-
-        files_in_base64 = [b64encode(file.read()).decode() for file in files]
+        files_in_base64 = [b64encode(file_stream).decode() for file_stream in file_streams]
         return render_template("evaluate.html", predictions=zip(files_in_base64, predictions))
     elif output == "json":
         predictions = [{"filename": file.filename, "tags": tags} for file, tags in zip(files, predictions)]
@@ -53,5 +119,33 @@ def evaluate():
         abort(400, description="Invalid output type")
 
 
+@app.route("/jobstatus", methods=["GET"])
+def job_status():
+    job_id: str = request.args.get("jobId")
+    output: str = request.values.get("format", "json")
+    if not job_id:
+        abort(404, description="Job not found")
+
+    job_info = job_results.get(job_id)
+    if not job_info:
+        abort(404, description="Job not found")
+
+    if job_info["status"] == "complete":
+        predictions = job_info["results"]
+        files = thread_to_files.get(job_id, [])
+        if output == "html":
+            files_in_base64 = [b64encode(file_stream).decode() for _, file_stream in files]
+            return render_template("evaluate.html", predictions=zip(files_in_base64, predictions))
+        elif output == "json":
+            predictions_json = [{"filename": filename, "tags": tags} for (filename, _), tags in zip(files, predictions)]
+            return jsonify(predictions_json)
+        else:
+            abort(400, description="Invalid output type")
+    else:
+        abort(404, description="Job still processing")
+
+
 if __name__ == "__main__":
+    batch_processing_manager_thread = threading.Thread(target=batch_manager, daemon=True)
+    batch_processing_manager_thread.start()
     app.run(host="0.0.0.0", port=int(os.getenv("PORT") or 8000), debug=os.getenv("DEBUG") == "True")

--- a/app.py
+++ b/app.py
@@ -13,7 +13,7 @@ from dotenv import load_dotenv
 from flask import Flask, request, render_template, jsonify, abort
 from werkzeug.datastructures import FileStorage
 
-from autotagger import Autotagger, ProcessImageException
+from autotagger import Autotagger
 
 load_dotenv()
 model_path = os.getenv("MODEL_PATH", "models/model.onnx")
@@ -99,15 +99,12 @@ def evaluate():
         else:
             abort(400, description="Invalid output type")
 
-    try:
-        predictions = list(autotagger.predict(
-            opened_files,
-            general_threshold=general_threshold,
-            character_threshold=character_threshold,
-            limit=limit,
-        ))
-    except ProcessImageException as process_image_exception:
-        abort(400, description=f"Error processing image file, {process_image_exception.message}.")
+    predictions = list(autotagger.predict(
+        opened_files,
+        general_threshold=general_threshold,
+        character_threshold=character_threshold,
+        limit=limit,
+    ))
 
     if output == "html":
         files_in_base64 = [b64encode(file_stream).decode() for file_stream in file_streams]

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ Flask==2.3.3
 pandas==2.2.2
 onnxruntime==1.19.2
 gunicorn==23.0.0
+Werkzeug==3.0.4

--- a/templates/index.html
+++ b/templates/index.html
@@ -2,11 +2,15 @@
 <html>
 <body>
 <form action="/evaluate" method="post" enctype="multipart/form-data">
-    <input type="file" name="file">
+    <input type="file" name="file" multiple>
     <input type="hidden" name="format" value="html">
     <input type="hidden" name="threshold" min="0" max="1" step="0.1" value="0.01">
     <input type="hidden" name="limit" value="100">
+    <label>
+        <input type="checkbox" name="get_id" value="true"> Get Job ID
+    </label>
     <input type="submit" value="Submit">
 </form>
 </body>
 </html>
+

--- a/templates/job_id_response.html
+++ b/templates/job_id_response.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Job ID</title>
+</head>
+<body>
+    <h1>Job ID</h1>
+    <p>Your job ID is: {{ job_id }}</p>
+    <p>Check the status of your job at <a href="/jobstatus?jobId={{ job_id }}&format=html">/jobstatus?jobId={{ job_id }}&format=html</a></p>
+    <a href="/">Back to home</a>
+</body>
+</html>
+

--- a/templates/job_status.html
+++ b/templates/job_status.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Job Status</title>
+</head>
+<body>
+    <h1>Job Status</h1>
+    <p>Job ID: {{ job_id }}</p>
+    <p>Status: {{ status }}</p>
+    {% if status == "complete" %}
+        <a href="/jobstatus?jobId={{ job_id }}">View Results</a>
+    {% endif %}
+    <a href="/">Back to home</a>
+</body>
+</html>
+


### PR DESCRIPTION
This commit addresses the PR "Job Status Check Endpoint"

"Some services may not want to keep a connection open to wait for the result after sending the image. Add an optional parameter in the POST request handler to return a job UUID immediately. You should set up an endpoint at /jobstatus that takes a GET request with a string field "jobId", which is the UUID of any running job. The endpoint should either return a 404 error if the results aren't available yet, or the result if the evaluation is complete."